### PR TITLE
Remove "hell" and "pawn" from the curses list

### DIFF
--- a/src/main/resources/curses.txt
+++ b/src/main/resources/curses.txt
@@ -408,7 +408,6 @@ orgasims
 orgasm
 orgasms 
 p0rn
-pawn
 pecker
 penis
 penisfucker


### PR DESCRIPTION
The bot considered "hello" as a curse because of "hell" being in the list. Also, I wouldn't really consider it as a curse :P 
"pawn" caused problems too, it was triggered every time someone said "spawn".
